### PR TITLE
Moderación automática

### DIFF
--- a/chat-service/app/Services/MessageService.php
+++ b/chat-service/app/Services/MessageService.php
@@ -8,10 +8,12 @@ use App\Models\Message;
 class MessageService
 {
     private ?array $friendIdsCache = null;
+    private ModerationService $moderationService;
     private SocialBlockService $socialBlockService;
 
     public function __construct()
     {
+        $this->moderationService = new ModerationService();
         $this->socialBlockService = new SocialBlockService();
     }
 
@@ -20,6 +22,8 @@ class MessageService
      */
     public function send(int $senderId, int $receiverId, ?string $content, ?string $imageUrl, string $jwt): Message
     {
+        $this->moderationService->ensureClean($content, 'message');
+
         if ($senderId === $receiverId) {
             throw new MessageServiceException('No puedes enviarte un mensaje a ti mismo', 422);
         }

--- a/chat-service/app/Services/ModerationService.php
+++ b/chat-service/app/Services/ModerationService.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services;
+
+class ModerationService
+{
+    private const DICTIONARY_PATH = 'app/Support/Moderation/profanity-es-hispano.txt';
+
+    /** @var array<string, bool>|null */
+    private static ?array $dictionary = null;
+
+    /** @var string[]|null */
+    private static ?array $phrases = null;
+
+    public function ensureClean(?string $text, string $contentType = 'contenido'): void
+    {
+        if (!$this->hasForbiddenLanguage($text)) {
+            return;
+        }
+
+        $messages = [
+            'post' => 'Tu publicacion contiene lenguaje no permitido.',
+            'comment' => 'Tu comentario contiene lenguaje no permitido.',
+            'message' => 'Tu mensaje contiene lenguaje no permitido.',
+            'content' => 'El contenido contiene lenguaje no permitido.',
+        ];
+
+        throw new \InvalidArgumentException($messages[$contentType] ?? $messages['content'], 422);
+    }
+
+    public function hasForbiddenLanguage(?string $text): bool
+    {
+        $normalized = $this->normalizeText($text);
+        if ($normalized === '') {
+            return false;
+        }
+
+        $dictionary = $this->loadDictionary();
+        $tokens = preg_split('/\s+/u', $normalized, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        foreach ($tokens as $token) {
+            if (isset($dictionary[$token])) {
+                return true;
+            }
+        }
+
+        $haystack = ' ' . $normalized . ' ';
+        foreach ($this->loadPhrases() as $phrase) {
+            if (str_contains($haystack, ' ' . $phrase . ' ')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function loadDictionary(): array
+    {
+        if (self::$dictionary !== null) {
+            return self::$dictionary;
+        }
+
+        $path = app()->basePath(self::DICTIONARY_PATH);
+        if (!is_file($path)) {
+            self::$dictionary = [];
+            self::$phrases = [];
+            return self::$dictionary;
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+        $dictionary = [];
+        $phrases = [];
+
+        foreach ($lines as $line) {
+            $normalized = $this->normalizeText($line);
+            if ($normalized === '') {
+                continue;
+            }
+
+            $dictionary[$normalized] = true;
+            if (str_contains($normalized, ' ')) {
+                $phrases[] = $normalized;
+            }
+        }
+
+        usort($phrases, fn (string $a, string $b) => mb_strlen($b) <=> mb_strlen($a));
+
+        self::$dictionary = $dictionary;
+        self::$phrases = $phrases;
+
+        return self::$dictionary;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function loadPhrases(): array
+    {
+        $this->loadDictionary();
+        return self::$phrases ?? [];
+    }
+
+    private function normalizeText(?string $text): string
+    {
+        if ($text === null) {
+            return '';
+        }
+
+        $value = trim((string) $text);
+        if ($value === '') {
+            return '';
+        }
+
+        $value = mb_strtolower($value, 'UTF-8');
+        $value = strtr($value, [
+            'á' => 'a', 'à' => 'a', 'ä' => 'a', 'â' => 'a',
+            'é' => 'e', 'è' => 'e', 'ë' => 'e', 'ê' => 'e',
+            'í' => 'i', 'ì' => 'i', 'ï' => 'i', 'î' => 'i',
+            'ó' => 'o', 'ò' => 'o', 'ö' => 'o', 'ô' => 'o',
+            'ú' => 'u', 'ù' => 'u', 'ü' => 'u', 'û' => 'u',
+            'ñ' => 'n',
+        ]);
+
+        $value = preg_replace('/[^\p{L}\p{N}]+/u', ' ', $value) ?? $value;
+        $value = preg_replace('/\s+/u', ' ', $value) ?? $value;
+
+        return trim($value);
+    }
+}

--- a/chat-service/app/Support/Moderation/profanity-es-hispano.meta.json
+++ b/chat-service/app/Support/Moderation/profanity-es-hispano.meta.json
@@ -1,0 +1,32 @@
+{
+  "generated_at": "2026-05-07T20:36:26.390Z",
+  "google_language": "es",
+  "sources": [
+    "npm:@coffeeandfun/google-profanity-words (es)",
+    "spanlp:ARG",
+    "spanlp:BOL",
+    "spanlp:CHL",
+    "spanlp:COL",
+    "spanlp:CRI",
+    "spanlp:CUB",
+    "spanlp:DOM",
+    "spanlp:ECU",
+    "spanlp:ESP",
+    "spanlp:GTM",
+    "spanlp:HND",
+    "spanlp:MEX",
+    "spanlp:NIC",
+    "spanlp:PAN",
+    "spanlp:PER",
+    "spanlp:PRI",
+    "spanlp:PRY",
+    "spanlp:SLV",
+    "spanlp:URY",
+    "spanlp:VEN"
+  ],
+  "counts": {
+    "google_words": 564,
+    "country_words": 1185,
+    "merged_words": 1344
+  }
+}

--- a/chat-service/app/Support/Moderation/profanity-es-hispano.txt
+++ b/chat-service/app/Support/Moderation/profanity-es-hispano.txt
@@ -1,0 +1,1344 @@
+2 chicas 1 taza
+2g1c
+4r5e
+5 hit
+5h1t
+a cuatro patas
+a la verga
+a pelo
+a tomar por culo
+a55
+abanto
+abombado
+abrazaderas de trebol
+abrazafarolas
+accion doble penetracion
+accion morena
+accion rubia
+acrotomofilia
+aculillao
+adufe
+adulador
+agacharsele el pico
+agueonao
+aguevado
+aguevao
+agujero de tapon
+ahueonao
+ahuevado
+ahuevonado
+alcornoque
+aldaba
+alfenique
+almohadas sucias
+amarrete
+anal
+analfabeto
+andar con la piedra o roca
+andrajoso
+andurriasmo
+anilingus
+animal
+ano
+apenas legal
+ar5e
+arepa
+arrastracueros
+arrecha
+arrechera
+arrecho
+arrimado
+artaban
+asaltante
+asno
+asno duende
+aspirar
+asqueroso
+assbanger
+asswipe
+atarre
+atontado
+atorrante
+atrevido
+auto erotico
+autoerotico
+aweonao
+awevado
+azada
+b00bs
+b17ch
+babeland
+babieca
+babieco
+baboso
+badulaque
+balin
+bampot
+banano
+bandido
+bang bros
+bano de oro
+barrabas
+barriobajero
+bastardo
+bastinado
+basura
+basurero
+batidor de pollas
+bbw
+bdsm
+bebecharcos
+bellaco
+belloto
+berzotas
+bestia
+bestial
+bestialidad
+besugo
+bien
+birlocha
+blandito
+boba
+bobalicon
+bobo
+boboleto
+bobolicon
+boca abierta
+boca de tonel
+bocabuzon
+bocachancla
+bocallanta
+bochinche
+bochinchudo
+bodoque
+bofe
+bofetada
+boiolas
+bola
+bolas
+boleta
+boletoso
+bollo
+bollok
+bollox
+bolsa
+bolsa de basura
+bolsa de culo
+bolsa de pelota
+bolsa de pene
+bolsillo caliente de alabama
+boludo
+bombril
+booooooobs
+boquimuelle
+borrachos
+borrico
+bostero
+botarate
+boton de cuero
+botones de mierda
+boyo
+brasas
+brida
+bromista
+bucefalo
+buceta
+buena caca
+buena chica
+buena mierda
+buey
+bufa
+bufo
+bukkake
+bullyke
+bulto
+bultuntun
+burro
+buscador de
+buscar
+cabeciduro
+cabestro
+cabeza de chorlito
+cabeza de gallo
+cabeza de guevo
+cabeza de machete
+cabeza de ponque
+cabeza de verga
+cabezaalberca
+cabezabuque
+cabilla
+cabra
+cabracx
+cabro
+cabron
+cabrona
+cabrones
+caca
+cacaso
+cachapera
+cachibache
+cachon
+cachorro
+cachudo
+cacorra
+cacorro
+cafe en las bolas
+cafre
+cagalindes
+cagalitroso
+cagapalo
+cagar
+cagarla
+cagarruta
+cagarse
+cagarte
+cago
+cagon
+cagon de mierda
+cagona
+caido del zarzo
+cajeta
+calabaza
+calambuco
+calamidad
+calduo
+caliche
+calienta guevo
+calientahielos
+caliente carl
+caligueva
+calzamonas
+camba
+camgirl
+camionero
+campana
+camwhore
+cana
+canalla
+canazo
+cangrejera
+cansalmas
+cantamananas
+canuto
+capot de volkswagen
+capotiar
+capullo
+capullos de rosa de chocolate
+cara de chocho
+cara de cojudo
+cara de culo
+cara de gallo
+cara de mierda
+cara de pene
+cara de pepa
+cara de pija
+cara de tabla
+cara de verga
+cara e feto
+caracaballo
+caracarton
+caraculo
+caraenalga
+caraepeo
+caraflema
+caraja
+carajaula
+carajo
+carajote
+carapapa
+carapijo
+carcunda
+care chimba
+care gorro
+care monda
+care pepa
+care picha
+care pija
+care pinga
+care verga
+carebarro
+caremonda
+caremuerto
+careperro
+carepi
+caretiesto
+careverga
+cargar
+carino
+carne con papas
+carnicero
+carteluo
+catacaldos
+cazurro
+cebillo
+cebilluo
+cebo de la carcel
+cebollino
+ceguegue
+cenizo
+cenutrio
+ceporro
+cernicalo
+cerote
+cerradura de pajaro
+chaqueta recta de cuero
+charran
+chavista
+cherna
+chica caliente
+chica en
+chicha
+chichar
+chiflado
+chiflar
+chimar
+chimbo
+chinchilla
+chinga
+chinga su madre
+chingada
+chingadera
+chingado
+chingando
+chingar
+chingo
+chingona
+chingoneria
+chiquilicuatre
+chirimbaina
+chisgarabis
+cho
+cho de la gran puta
+choad
+chocha
+chocho
+chode
+chola
+chola e burro
+choro
+chorra
+chorros femeninos
+chorros masculinos
+chota
+choto
+chucha
+chucha e culo
+chuchesumadre
+chuchita
+chulo
+chunchurria
+chupa culo
+chupacables
+chupador de culos
+chupame la raja
+chupando bolas
+chupapija
+chupapinga
+chupapollas
+chupasangre
+chupe verga
+chupelo
+chupeme la picha
+chupoptero
+churre
+churri
+chusma
+chuta
+ciberfuckers
+cibernetico
+cierrabares
+cipa
+cipote
+circulo idiota
+cita
+cl1t
+clitoris
+coca
+cochesumadre
+cochina
+cochon
+cocinando
+cockmongruel
+cocolla
+codiciando
+codo
+coger
+coito
+coje culo
+cojeculo
+cojer
+cojio
+cojonera
+cojones
+cojonudo
+cojudo
+coksucka
+colla
+collera
+coma mierda
+comadreja
+come chicle
+come huevo
+come mi culo
+come mierda
+come moco
+comebolsas
+comechapas
+comeflores
+comegato
+comemierda
+comepollas
+comestacas
+como asesinar
+como matar
+conaso
+conaza
+conazo
+concha
+concha de tu madre
+conchatumare
+conchesumare
+conchetumadre
+conejito hijo de puta
+confianza de perro
+conito
+cono
+cono de madre
+cono de tu pepa
+conos
+consolador
+consoladores
+coochie
+cooter
+coprofago
+coprofilia
+coprolagnia
+coquetear
+corneo
+cornhole
+correrse
+corrida
+covero
+coviao
+craputoso
+cremita
+cresta
+cretino
+cuaima
+cuatriboliao
+cuca
+cucaracha
+cuchara
+cuchillo de castor
+cueca
+cueco
+cuecon
+cuero
+cuerpoescombro
+cuervo
+cuita
+cuite
+culantro
+culata
+cule
+culeado
+culeao
+culear
+culebra
+culero
+culia
+culiabierto
+culiao
+culiar
+culillo
+culilluo
+culo
+culo gay
+culo mono
+culo-gorro
+culo-pirata
+culopollo
+culos
+cummer
+cumming
+cunilingus
+cunillingus
+cunnilingus
+cuntrag
+cunumi
+curda
+curdo
+currutaca
+cursalera
+cyalis
+cyberfuc
+cyberfuck
+d1ck
+da asco
+dar por culo
+de balde
+de pinga
+dedo de camello
+dedo follado
+delputas
+dendrofilia
+desahuevate
+descarao
+descerebrado
+desgarracalzas
+desgraciada
+desgraciado
+desmoronamiento
+desnudo
+desorejada
+desorejado
+devorador de semen
+dickleche
+dickweed
+digitacion
+dique
+direccion
+disoluto
+dlck
+doble hijueputa
+doble penetracion
+doble polla
+doblehijueputa
+dolcett
+dominacion
+dominacion femenina
+dominatriz
+domos
+dondiego
+donnadie
+doosh
+drogo
+ducha
+duchas marrones
+dundo
+duro
+dvda
+ecchi
+echacantos
+ejarramantas
+el ella
+empacador de chocolate
+empaquetador de dulces
+enchavar
+enculada
+energumeno
+enganapichanga
+erg
+erga
+erotico
+erotismo
+esbaratabailes
+esbirro
+esclavitud
+escolimoso
+escolta
+escornacabras
+escualido
+esperma
+espundia
+esputo
+estilo perrito
+estilo perro
+estolido
+estulto
+estupideces
+estupido
+eunuco
+eyacula
+eyaculacion
+eyaculado
+eyaculando
+eyacular
+f4nny
+facilota
+facineroso
+fanfosquero
+fannyflaps
+fannyfucker
+fantoche
+fanyy
+fariseo
+fecal
+feck
+federico
+felacion
+felch
+felching
+felon
+felona
+fetichismo de pies
+feyuco
+fieltro
+fiesta de limon
+fijandose
+filimincias
+flete
+fletera
+flojo
+foligoso
+folla
+folla con los dedos
+folla con los punos
+follada
+follador de culo
+follador de dedos
+follador de perros
+follador de punos
+folladores de dedos
+folladores de punos
+follame
+follando
+follando con el puno
+follando con los dedos
+follando con los punos
+follar
+follar con el puno
+follar con los dedos
+folle
+follen
+follona
+forro
+forro de caballo
+freson
+frijol
+frijoles
+frotandose
+fuk
+fuker
+fukker
+fukkin
+fuks
+fukwhit
+fukwit
+fulastre
+fumador de pollas
+fumeque
+fumon
+fundillo
+furby
+futanari
+fux0r
+gallina
+gallo
+gallo negro
+gamberra
+ganan
+ganapan
+ganapio
+gandul
+gangbanged
+ganso
+garbimba
+garganta profunda
+garrancha
+garrancho
+garrote
+gatorade
+gaver
+gay
+gaybob
+gaydo
+gaywad
+gaznapiro
+genitales
+geva
+gil
+gilipollas
+gilipuertas
+giraesquinas
+gocho
+gofre azul
+gokkun
+golpe
+golpe de ala
+gonorrea
+gooch
+gordo
+gordo enorme
+goregasmo
+gorrero
+gorrino
+gorron
+gorrumino
+gran doble hijueputa
+gran puta
+grande y negro
+grandes aldabas
+grandes tetas
+granizo
+grantriplehijueputa
+graznar
+grieta
+gringo
+guarayo
+guate
+guebon
+gueleguele
+guevazo
+guevon
+guevona
+guido
+guiso
+guitarro
+guro
+gurriato
+gurrupleta
+gurrupleto
+habahela
+hacerse una paja
+haciendo el amor
+hala bola
+hamburguesa
+hazme llegar
+heeb
+hentai
+herrero
+hija de puta
+hijaeputa
+hijo de diablo
+hijo de la gran flauta
+hijo de la gran puta
+hijo de la perra
+hijo de las siete leches
+hijo de perra
+hijo de puta
+hijoeputa
+hijos de puta
+hijuefruta
+hijuelaverga
+hijueperra
+hijueputa
+hipocrita
+ho
+hoar
+hoare
+hominicaca
+hominicaco
+homo
+homoerotico
+honky
+horre
+hostia
+hoyo
+hoyuda
+hueco
+huele huele
+huele vicho
+huelegateras
+hueon
+huevada
+hueveo
+huevo
+huevon
+huevona
+huevonada
+idiota
+imbecil
+imbeciles
+imilla
+incesto
+incrospido
+indio
+infierno
+inflador
+ingnorante
+ir a tientas
+jailbait
+jaime
+jala bola
+jalla
+jallo
+jambeco
+japon
+jartera
+jeva
+jigaboo
+jiggerboo
+jinetera
+jism
+jockey
+joder
+jodido
+joputa
+joroba seca
+joto
+jueputa
+jugado de cegua
+juggs
+jugo de bebe
+jugo de polla
+kara
+kawk
+kilua
+kinbaku
+kiunt
+kondum
+kondums
+kum
+kumer
+kummer
+kums
+kunilingus
+kunt
+kyke
+l3i+ch
+la concha de la lora
+la penca del burro
+labios
+labios de castor
+ladilla
+ladillaa
+ladillao
+ladron de traseros
+lambetuerca
+lambevicho
+lambon
+lambusia
+lamecharcos
+lameconos
+lameculo
+lameculos
+lameplatos
+lamer el cono
+lamer el culo
+lamiendo conos
+lampara
+lamparoso
+lanzallamas
+lary
+las chicas se volvieron locas
+lechugino
+lechuguin
+lechuguino
+lelo
+lengua en el estuche
+leproso
+lerdo
+lesbiana
+lesbo
+lichigo
+llaga
+llamada de botin
+llamon
+llamona
+llokalla
+lmfao
+loba
+loca
+loco de mierda
+locota
+lolita
+lujuria
+luser
+m0f0
+m0fo
+m45terbato
+ma5terb8
+ma5terbato
+macaco
+macana
+machete
+macheterico
+maduro
+maestro de gallos
+maestro murcielago*
+maestro parcha
+maestro-bate
+maestrob8
+magapa
+maje
+majunche
+mal aliento
+mal cogida
+mala hoja
+malagente
+malandra
+malandro
+maldicienta
+maldiciento
+maldicion
+maldita
+maldita rata
+maldita sea
+maldito
+malditos
+malfollao
+mallen
+malparia
+malparida
+malparido
+malpario
+mama culo
+mama huevo
+mama picha
+mama vicho
+mamacallos
+mamada
+mamada pbc
+mamadas
+mamador de paloma,
+mamagueva
+mamagueveteo
+mamaguevo
+mamando
+mamao
+mamar
+mamarracha
+mamarracho
+mamavicho
+mamelo
+mamera
+mamon
+mandao
+mando
+manguarrian
+manuela
+mapache
+mapaches
+maraco
+marica
+maricas
+marico
+marico preso
+marico triste
+maricon
+mariconear
+mariconzon
+mariflor
+marihuanero
+mariquita
+marperio
+mas caliente
+masa para bebes
+mascador de alfombras
+mascador de culos
+maseta
+masoquista
+masterbacion
+masterbaciones
+masterbat3
+masterbate
+masticador de alfombras
+masticar trasero
+masturbacion
+masturbar
+masturbarse
+matosurrero
+me cago en su madre
+me llegas al pincho
+me pelas la pija
+me vale verga
+meapilas
+meason
+mecaniquito
+menaje
+menopausica
+menso
+mentirosa
+mentiroso
+mercachifle
+metedura de pata
+metelo
+metomentodo
+mica
+micha
+michita
+mico
+microondas
+mierda
+mierdamierdahijo de puta
+mierdoza
+mierdozo
+mio
+moclin
+moco
+moja’ el picure
+mojonero
+monda
+mongol
+mongolico
+mongolo
+mono gallo
+moquito
+moras
+mordaza de bola
+mordedura de gallo
+mordida
+moreno
+morlaco
+moromierda
+morronga
+mostro
+mota
+muerdealmohada
+muergana
+muergano
+mula
+nabo
+nalgas
+nariz de gallo
+nazi
+negro
+neja
+nejo
+nengue
+nera
+nero
+nica
+niche
+nina en la cima
+no jodas
+no sirves pa ni mierda
+nojo
+nojoda
+nona
+noneco
+nono
+nucleo duro
+nudoso
+nuez
+ocote
+ojete
+oleoducto de alaska
+olluo
+orgia
+orgias
+ortiva
+orto
+ostia
+pacharro
+paco
+pacucuso
+pacufo
+pacuso
+pacusobo
+paga peo
+paga prote
+pagafantas
+paja
+paja de pies
+pajaro
+pajaron
+pajizo
+pajua
+pajuo
+pajuso
+palo
+paloma
+panal caga’o
+pandorga
+panocha
+papaya
+papo
+parcha
+parchita
+pargo
+pargula
+parido por el sobaco
+pasmado
+pastelero
+pastrulo
+pata e’ rolo
+patear el tobo
+patear la pelota
+pato
+payaso
+pea
+pechos grandes
+pecuso
+pedazo de mierda
+pedo
+pedofilo
+pegoste de olla
+peinabombillas
+pelele
+pelota lamiendo
+pelotas
+pelotudo
+penco
+pencon
+pendeja
+pendejo
+pene
+peo
+pepa del culo
+pepita
+perilla
+perillaoriental
+perillas
+perra
+perras
+perro
+perro e’ quinta
+perro e’ rancho
+perroflauta
+persiguiendo
+pervertido
+pete
+petimetre
+petizo
+pezcao
+picador
+picazon
+picha
+pichicosa
+pichinga
+pichon de cabron
+pichurria
+pico
+pie de atleta
+pija
+pijotero
+pincharrata
+pinche
+pinga
+pingo
+pipian
+pirinola
+piripicho
+piroba
+pirobo
+pisa
+pisa huevos
+pisa ninas
+pistola con la mano
+pitillo
+plaga
+plasta
+playo
+plegocha
+pocha
+polla
+polla gigante
+pollas
+pollasuka
+pollerudo
+poluta
+poluto
+polvo del gallo
+polvo del kerosene
+ponche de burro
+pordiosero
+porqueria
+porton de iglesia
+poto
+pozo
+primo
+prostituta
+pucha
+puchica
+pullar
+pullon
+puneta
+puno
+puno follado
+punto g
+pupu
+purruja
+puta
+puta de la cam
+puta madre
+putas
+puto
+putona
+puya
+quejandose
+quemero
+querrequerre
+queso
+quesua
+quesuo
+racamofin
+racimo de mierda
+raja
+rajunarepa
+ramera
+rata
+ratica
+realengo
+recochesumadre
+reconchesumare
+reconchetumadre
+recontra cono’e madre
+recontraconisimo
+recontraputa
+redoblona
+relambe guevo
+relambechupaverga
+relambepipe
+remojar el cochayuyo
+repipi
+reputa
+reputisima
+restriccion de cuero
+retrasado
+ridi
+ridiculo
+rizado
+rodaja de pina
+rolitranco
+rompeculos
+rosalada
+rosquete
+rosquilla de gelatina
+rozar las pelotas
+rubia sobre rubia accion
+ruchar
+sabolo
+saco de bolas
+saco de pelota
+saideliu
+salsa de bolas
+sambumbia
+samo
+sanaco
+sangriento
+sapa
+sapo
+sapo hijueputa
+se corre
+sebuda
+sebudo
+semen
+senor gay
+senos
+serrana
+serrano
+serruchar
+sexo caliente
+sexo duro
+sexo en grupo
+sexo gay
+si como ronca duerma
+sieso
+simeloma
+sin cojones
+sobraa
+sobrao
+socabron
+somamao
+sonzo
+sopendejo
+sopla condon
+sopla tu carga
+soplar el bisteck
+soplon
+su madre
+sucio
+sucio sanchez
+tacazo
+tara
+tarado
+taraila
+tarao
+tardo gay
+tarupido
+tatengue
+tavy
+temiga
+temigoso
+temigue
+tenso
+terruco
+teta
+tetas
+tetona
+tierruo
+timbal
+timonel
+tio
+tirado un pedo
+tirador
+tirando pedos
+tirar
+tirilla
+tiuque
+tocapelotas
+toche
+tontarron
+tontas
+tonterias
+tonto
+topar
+tortillera
+toto
+totona
+trabajo manual
+traficante de gallos
+traficante de pollas
+traga sable
+tragaleche
+tragasable
+trampolindebuchevergaoriental
+tranca
+trancado
+trasero
+trasero-pirata
+trastanuta
+travesti
+trimardito
+tripero
+triplehijueputa
+trolo
+tu madre
+tu taa loco
+tufo
+tuki
+tunco
+tusa
+tutifruto
+una mierda
+uyuyuy
+vaina
+vale picha
+vapor de cleveland
+vasito de agua
+venado
+venatica
+venatico
+verano
+verdugo
+verga
+vergacion
+vergatario
+verraco
+verriondo
+vete a la chingada
+veterano
+vibra de bala
+vicho
+violacion en una cita
+violin
+volar papagallo
+vuerga
+webon
+webonauta
+weon
+wepota
+wircha
+wircho
+wiro
+wueon
+xonga
+xongo
+yoyo
+zamarro
+zamuro
+zarzamora
+zascandil
+zingar
+zoquete
+zorimba
+zorimbo
+zorra
+zorritone
+zorro
+zorrupia
+zunga
+zurdo
+zurumbatico

--- a/posts-service/app/Services/CommentService.php
+++ b/posts-service/app/Services/CommentService.php
@@ -9,16 +9,20 @@ use App\Models\Post;
 class CommentService
 {
     private CommentLikeService $commentReactionService;
+    private ModerationService $moderationService;
     private SocialBlockService $socialBlockService;
 
     public function __construct()
     {
         $this->commentReactionService = new CommentLikeService();
+        $this->moderationService = new ModerationService();
         $this->socialBlockService = new SocialBlockService();
     }
 
     public function store(int $userId, int $postId, string $content, array $meta = [], string $jwt = ''): Comment
     {
+        $this->moderationService->ensureClean($content, 'comment');
+
         $post = Post::find($postId);
         if (!$post) {
             throw new PostsServiceException('Publicacion no encontrada', 404);

--- a/posts-service/app/Services/ModerationService.php
+++ b/posts-service/app/Services/ModerationService.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services;
+
+class ModerationService
+{
+    private const DICTIONARY_PATH = 'app/Support/Moderation/profanity-es-hispano.txt';
+
+    /** @var array<string, bool>|null */
+    private static ?array $dictionary = null;
+
+    /** @var string[]|null */
+    private static ?array $phrases = null;
+
+    public function ensureClean(?string $text, string $contentType = 'contenido'): void
+    {
+        if (!$this->hasForbiddenLanguage($text)) {
+            return;
+        }
+
+        $messages = [
+            'post' => 'Tu publicacion contiene lenguaje no permitido.',
+            'comment' => 'Tu comentario contiene lenguaje no permitido.',
+            'message' => 'Tu mensaje contiene lenguaje no permitido.',
+            'content' => 'El contenido contiene lenguaje no permitido.',
+        ];
+
+        throw new \InvalidArgumentException($messages[$contentType] ?? $messages['content'], 422);
+    }
+
+    public function hasForbiddenLanguage(?string $text): bool
+    {
+        $normalized = $this->normalizeText($text);
+        if ($normalized === '') {
+            return false;
+        }
+
+        $dictionary = $this->loadDictionary();
+        $tokens = preg_split('/\s+/u', $normalized, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        foreach ($tokens as $token) {
+            if (isset($dictionary[$token])) {
+                return true;
+            }
+        }
+
+        $haystack = ' ' . $normalized . ' ';
+        foreach ($this->loadPhrases() as $phrase) {
+            if (str_contains($haystack, ' ' . $phrase . ' ')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    private function loadDictionary(): array
+    {
+        if (self::$dictionary !== null) {
+            return self::$dictionary;
+        }
+
+        $path = app()->basePath(self::DICTIONARY_PATH);
+        if (!is_file($path)) {
+            self::$dictionary = [];
+            self::$phrases = [];
+            return self::$dictionary;
+        }
+
+        $lines = file($path, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES) ?: [];
+        $dictionary = [];
+        $phrases = [];
+
+        foreach ($lines as $line) {
+            $normalized = $this->normalizeText($line);
+            if ($normalized === '') {
+                continue;
+            }
+
+            $dictionary[$normalized] = true;
+            if (str_contains($normalized, ' ')) {
+                $phrases[] = $normalized;
+            }
+        }
+
+        usort($phrases, fn (string $a, string $b) => mb_strlen($b) <=> mb_strlen($a));
+
+        self::$dictionary = $dictionary;
+        self::$phrases = $phrases;
+
+        return self::$dictionary;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function loadPhrases(): array
+    {
+        $this->loadDictionary();
+        return self::$phrases ?? [];
+    }
+
+    private function normalizeText(?string $text): string
+    {
+        if ($text === null) {
+            return '';
+        }
+
+        $value = trim((string) $text);
+        if ($value === '') {
+            return '';
+        }
+
+        $value = mb_strtolower($value, 'UTF-8');
+        $value = strtr($value, [
+            'á' => 'a', 'à' => 'a', 'ä' => 'a', 'â' => 'a',
+            'é' => 'e', 'è' => 'e', 'ë' => 'e', 'ê' => 'e',
+            'í' => 'i', 'ì' => 'i', 'ï' => 'i', 'î' => 'i',
+            'ó' => 'o', 'ò' => 'o', 'ö' => 'o', 'ô' => 'o',
+            'ú' => 'u', 'ù' => 'u', 'ü' => 'u', 'û' => 'u',
+            'ñ' => 'n',
+        ]);
+
+        $value = preg_replace('/[^\p{L}\p{N}]+/u', ' ', $value) ?? $value;
+        $value = preg_replace('/\s+/u', ' ', $value) ?? $value;
+
+        return trim($value);
+    }
+}

--- a/posts-service/app/Services/PostService.php
+++ b/posts-service/app/Services/PostService.php
@@ -7,15 +7,19 @@ use App\Models\Post;
 
 class PostService
 {
+    private ModerationService $moderationService;
     private SocialBlockService $socialBlockService;
 
     public function __construct()
     {
+        $this->moderationService = new ModerationService();
         $this->socialBlockService = new SocialBlockService();
     }
 
     public function create(int $userId, array $data): Post
     {
+        $this->moderationService->ensureClean($data['content'] ?? null, 'post');
+
         return Post::create([
             'user_id' => $userId,
             'group_id' => $data['group_id'] ?? null,

--- a/posts-service/app/Support/Moderation/profanity-es-hispano.meta.json
+++ b/posts-service/app/Support/Moderation/profanity-es-hispano.meta.json
@@ -1,0 +1,32 @@
+{
+  "generated_at": "2026-05-07T20:36:26.390Z",
+  "google_language": "es",
+  "sources": [
+    "npm:@coffeeandfun/google-profanity-words (es)",
+    "spanlp:ARG",
+    "spanlp:BOL",
+    "spanlp:CHL",
+    "spanlp:COL",
+    "spanlp:CRI",
+    "spanlp:CUB",
+    "spanlp:DOM",
+    "spanlp:ECU",
+    "spanlp:ESP",
+    "spanlp:GTM",
+    "spanlp:HND",
+    "spanlp:MEX",
+    "spanlp:NIC",
+    "spanlp:PAN",
+    "spanlp:PER",
+    "spanlp:PRI",
+    "spanlp:PRY",
+    "spanlp:SLV",
+    "spanlp:URY",
+    "spanlp:VEN"
+  ],
+  "counts": {
+    "google_words": 564,
+    "country_words": 1185,
+    "merged_words": 1344
+  }
+}

--- a/posts-service/app/Support/Moderation/profanity-es-hispano.txt
+++ b/posts-service/app/Support/Moderation/profanity-es-hispano.txt
@@ -1,0 +1,1344 @@
+2 chicas 1 taza
+2g1c
+4r5e
+5 hit
+5h1t
+a cuatro patas
+a la verga
+a pelo
+a tomar por culo
+a55
+abanto
+abombado
+abrazaderas de trebol
+abrazafarolas
+accion doble penetracion
+accion morena
+accion rubia
+acrotomofilia
+aculillao
+adufe
+adulador
+agacharsele el pico
+agueonao
+aguevado
+aguevao
+agujero de tapon
+ahueonao
+ahuevado
+ahuevonado
+alcornoque
+aldaba
+alfenique
+almohadas sucias
+amarrete
+anal
+analfabeto
+andar con la piedra o roca
+andrajoso
+andurriasmo
+anilingus
+animal
+ano
+apenas legal
+ar5e
+arepa
+arrastracueros
+arrecha
+arrechera
+arrecho
+arrimado
+artaban
+asaltante
+asno
+asno duende
+aspirar
+asqueroso
+assbanger
+asswipe
+atarre
+atontado
+atorrante
+atrevido
+auto erotico
+autoerotico
+aweonao
+awevado
+azada
+b00bs
+b17ch
+babeland
+babieca
+babieco
+baboso
+badulaque
+balin
+bampot
+banano
+bandido
+bang bros
+bano de oro
+barrabas
+barriobajero
+bastardo
+bastinado
+basura
+basurero
+batidor de pollas
+bbw
+bdsm
+bebecharcos
+bellaco
+belloto
+berzotas
+bestia
+bestial
+bestialidad
+besugo
+bien
+birlocha
+blandito
+boba
+bobalicon
+bobo
+boboleto
+bobolicon
+boca abierta
+boca de tonel
+bocabuzon
+bocachancla
+bocallanta
+bochinche
+bochinchudo
+bodoque
+bofe
+bofetada
+boiolas
+bola
+bolas
+boleta
+boletoso
+bollo
+bollok
+bollox
+bolsa
+bolsa de basura
+bolsa de culo
+bolsa de pelota
+bolsa de pene
+bolsillo caliente de alabama
+boludo
+bombril
+booooooobs
+boquimuelle
+borrachos
+borrico
+bostero
+botarate
+boton de cuero
+botones de mierda
+boyo
+brasas
+brida
+bromista
+bucefalo
+buceta
+buena caca
+buena chica
+buena mierda
+buey
+bufa
+bufo
+bukkake
+bullyke
+bulto
+bultuntun
+burro
+buscador de
+buscar
+cabeciduro
+cabestro
+cabeza de chorlito
+cabeza de gallo
+cabeza de guevo
+cabeza de machete
+cabeza de ponque
+cabeza de verga
+cabezaalberca
+cabezabuque
+cabilla
+cabra
+cabracx
+cabro
+cabron
+cabrona
+cabrones
+caca
+cacaso
+cachapera
+cachibache
+cachon
+cachorro
+cachudo
+cacorra
+cacorro
+cafe en las bolas
+cafre
+cagalindes
+cagalitroso
+cagapalo
+cagar
+cagarla
+cagarruta
+cagarse
+cagarte
+cago
+cagon
+cagon de mierda
+cagona
+caido del zarzo
+cajeta
+calabaza
+calambuco
+calamidad
+calduo
+caliche
+calienta guevo
+calientahielos
+caliente carl
+caligueva
+calzamonas
+camba
+camgirl
+camionero
+campana
+camwhore
+cana
+canalla
+canazo
+cangrejera
+cansalmas
+cantamananas
+canuto
+capot de volkswagen
+capotiar
+capullo
+capullos de rosa de chocolate
+cara de chocho
+cara de cojudo
+cara de culo
+cara de gallo
+cara de mierda
+cara de pene
+cara de pepa
+cara de pija
+cara de tabla
+cara de verga
+cara e feto
+caracaballo
+caracarton
+caraculo
+caraenalga
+caraepeo
+caraflema
+caraja
+carajaula
+carajo
+carajote
+carapapa
+carapijo
+carcunda
+care chimba
+care gorro
+care monda
+care pepa
+care picha
+care pija
+care pinga
+care verga
+carebarro
+caremonda
+caremuerto
+careperro
+carepi
+caretiesto
+careverga
+cargar
+carino
+carne con papas
+carnicero
+carteluo
+catacaldos
+cazurro
+cebillo
+cebilluo
+cebo de la carcel
+cebollino
+ceguegue
+cenizo
+cenutrio
+ceporro
+cernicalo
+cerote
+cerradura de pajaro
+chaqueta recta de cuero
+charran
+chavista
+cherna
+chica caliente
+chica en
+chicha
+chichar
+chiflado
+chiflar
+chimar
+chimbo
+chinchilla
+chinga
+chinga su madre
+chingada
+chingadera
+chingado
+chingando
+chingar
+chingo
+chingona
+chingoneria
+chiquilicuatre
+chirimbaina
+chisgarabis
+cho
+cho de la gran puta
+choad
+chocha
+chocho
+chode
+chola
+chola e burro
+choro
+chorra
+chorros femeninos
+chorros masculinos
+chota
+choto
+chucha
+chucha e culo
+chuchesumadre
+chuchita
+chulo
+chunchurria
+chupa culo
+chupacables
+chupador de culos
+chupame la raja
+chupando bolas
+chupapija
+chupapinga
+chupapollas
+chupasangre
+chupe verga
+chupelo
+chupeme la picha
+chupoptero
+churre
+churri
+chusma
+chuta
+ciberfuckers
+cibernetico
+cierrabares
+cipa
+cipote
+circulo idiota
+cita
+cl1t
+clitoris
+coca
+cochesumadre
+cochina
+cochon
+cocinando
+cockmongruel
+cocolla
+codiciando
+codo
+coger
+coito
+coje culo
+cojeculo
+cojer
+cojio
+cojonera
+cojones
+cojonudo
+cojudo
+coksucka
+colla
+collera
+coma mierda
+comadreja
+come chicle
+come huevo
+come mi culo
+come mierda
+come moco
+comebolsas
+comechapas
+comeflores
+comegato
+comemierda
+comepollas
+comestacas
+como asesinar
+como matar
+conaso
+conaza
+conazo
+concha
+concha de tu madre
+conchatumare
+conchesumare
+conchetumadre
+conejito hijo de puta
+confianza de perro
+conito
+cono
+cono de madre
+cono de tu pepa
+conos
+consolador
+consoladores
+coochie
+cooter
+coprofago
+coprofilia
+coprolagnia
+coquetear
+corneo
+cornhole
+correrse
+corrida
+covero
+coviao
+craputoso
+cremita
+cresta
+cretino
+cuaima
+cuatriboliao
+cuca
+cucaracha
+cuchara
+cuchillo de castor
+cueca
+cueco
+cuecon
+cuero
+cuerpoescombro
+cuervo
+cuita
+cuite
+culantro
+culata
+cule
+culeado
+culeao
+culear
+culebra
+culero
+culia
+culiabierto
+culiao
+culiar
+culillo
+culilluo
+culo
+culo gay
+culo mono
+culo-gorro
+culo-pirata
+culopollo
+culos
+cummer
+cumming
+cunilingus
+cunillingus
+cunnilingus
+cuntrag
+cunumi
+curda
+curdo
+currutaca
+cursalera
+cyalis
+cyberfuc
+cyberfuck
+d1ck
+da asco
+dar por culo
+de balde
+de pinga
+dedo de camello
+dedo follado
+delputas
+dendrofilia
+desahuevate
+descarao
+descerebrado
+desgarracalzas
+desgraciada
+desgraciado
+desmoronamiento
+desnudo
+desorejada
+desorejado
+devorador de semen
+dickleche
+dickweed
+digitacion
+dique
+direccion
+disoluto
+dlck
+doble hijueputa
+doble penetracion
+doble polla
+doblehijueputa
+dolcett
+dominacion
+dominacion femenina
+dominatriz
+domos
+dondiego
+donnadie
+doosh
+drogo
+ducha
+duchas marrones
+dundo
+duro
+dvda
+ecchi
+echacantos
+ejarramantas
+el ella
+empacador de chocolate
+empaquetador de dulces
+enchavar
+enculada
+energumeno
+enganapichanga
+erg
+erga
+erotico
+erotismo
+esbaratabailes
+esbirro
+esclavitud
+escolimoso
+escolta
+escornacabras
+escualido
+esperma
+espundia
+esputo
+estilo perrito
+estilo perro
+estolido
+estulto
+estupideces
+estupido
+eunuco
+eyacula
+eyaculacion
+eyaculado
+eyaculando
+eyacular
+f4nny
+facilota
+facineroso
+fanfosquero
+fannyflaps
+fannyfucker
+fantoche
+fanyy
+fariseo
+fecal
+feck
+federico
+felacion
+felch
+felching
+felon
+felona
+fetichismo de pies
+feyuco
+fieltro
+fiesta de limon
+fijandose
+filimincias
+flete
+fletera
+flojo
+foligoso
+folla
+folla con los dedos
+folla con los punos
+follada
+follador de culo
+follador de dedos
+follador de perros
+follador de punos
+folladores de dedos
+folladores de punos
+follame
+follando
+follando con el puno
+follando con los dedos
+follando con los punos
+follar
+follar con el puno
+follar con los dedos
+folle
+follen
+follona
+forro
+forro de caballo
+freson
+frijol
+frijoles
+frotandose
+fuk
+fuker
+fukker
+fukkin
+fuks
+fukwhit
+fukwit
+fulastre
+fumador de pollas
+fumeque
+fumon
+fundillo
+furby
+futanari
+fux0r
+gallina
+gallo
+gallo negro
+gamberra
+ganan
+ganapan
+ganapio
+gandul
+gangbanged
+ganso
+garbimba
+garganta profunda
+garrancha
+garrancho
+garrote
+gatorade
+gaver
+gay
+gaybob
+gaydo
+gaywad
+gaznapiro
+genitales
+geva
+gil
+gilipollas
+gilipuertas
+giraesquinas
+gocho
+gofre azul
+gokkun
+golpe
+golpe de ala
+gonorrea
+gooch
+gordo
+gordo enorme
+goregasmo
+gorrero
+gorrino
+gorron
+gorrumino
+gran doble hijueputa
+gran puta
+grande y negro
+grandes aldabas
+grandes tetas
+granizo
+grantriplehijueputa
+graznar
+grieta
+gringo
+guarayo
+guate
+guebon
+gueleguele
+guevazo
+guevon
+guevona
+guido
+guiso
+guitarro
+guro
+gurriato
+gurrupleta
+gurrupleto
+habahela
+hacerse una paja
+haciendo el amor
+hala bola
+hamburguesa
+hazme llegar
+heeb
+hentai
+herrero
+hija de puta
+hijaeputa
+hijo de diablo
+hijo de la gran flauta
+hijo de la gran puta
+hijo de la perra
+hijo de las siete leches
+hijo de perra
+hijo de puta
+hijoeputa
+hijos de puta
+hijuefruta
+hijuelaverga
+hijueperra
+hijueputa
+hipocrita
+ho
+hoar
+hoare
+hominicaca
+hominicaco
+homo
+homoerotico
+honky
+horre
+hostia
+hoyo
+hoyuda
+hueco
+huele huele
+huele vicho
+huelegateras
+hueon
+huevada
+hueveo
+huevo
+huevon
+huevona
+huevonada
+idiota
+imbecil
+imbeciles
+imilla
+incesto
+incrospido
+indio
+infierno
+inflador
+ingnorante
+ir a tientas
+jailbait
+jaime
+jala bola
+jalla
+jallo
+jambeco
+japon
+jartera
+jeva
+jigaboo
+jiggerboo
+jinetera
+jism
+jockey
+joder
+jodido
+joputa
+joroba seca
+joto
+jueputa
+jugado de cegua
+juggs
+jugo de bebe
+jugo de polla
+kara
+kawk
+kilua
+kinbaku
+kiunt
+kondum
+kondums
+kum
+kumer
+kummer
+kums
+kunilingus
+kunt
+kyke
+l3i+ch
+la concha de la lora
+la penca del burro
+labios
+labios de castor
+ladilla
+ladillaa
+ladillao
+ladron de traseros
+lambetuerca
+lambevicho
+lambon
+lambusia
+lamecharcos
+lameconos
+lameculo
+lameculos
+lameplatos
+lamer el cono
+lamer el culo
+lamiendo conos
+lampara
+lamparoso
+lanzallamas
+lary
+las chicas se volvieron locas
+lechugino
+lechuguin
+lechuguino
+lelo
+lengua en el estuche
+leproso
+lerdo
+lesbiana
+lesbo
+lichigo
+llaga
+llamada de botin
+llamon
+llamona
+llokalla
+lmfao
+loba
+loca
+loco de mierda
+locota
+lolita
+lujuria
+luser
+m0f0
+m0fo
+m45terbato
+ma5terb8
+ma5terbato
+macaco
+macana
+machete
+macheterico
+maduro
+maestro de gallos
+maestro murcielago*
+maestro parcha
+maestro-bate
+maestrob8
+magapa
+maje
+majunche
+mal aliento
+mal cogida
+mala hoja
+malagente
+malandra
+malandro
+maldicienta
+maldiciento
+maldicion
+maldita
+maldita rata
+maldita sea
+maldito
+malditos
+malfollao
+mallen
+malparia
+malparida
+malparido
+malpario
+mama culo
+mama huevo
+mama picha
+mama vicho
+mamacallos
+mamada
+mamada pbc
+mamadas
+mamador de paloma,
+mamagueva
+mamagueveteo
+mamaguevo
+mamando
+mamao
+mamar
+mamarracha
+mamarracho
+mamavicho
+mamelo
+mamera
+mamon
+mandao
+mando
+manguarrian
+manuela
+mapache
+mapaches
+maraco
+marica
+maricas
+marico
+marico preso
+marico triste
+maricon
+mariconear
+mariconzon
+mariflor
+marihuanero
+mariquita
+marperio
+mas caliente
+masa para bebes
+mascador de alfombras
+mascador de culos
+maseta
+masoquista
+masterbacion
+masterbaciones
+masterbat3
+masterbate
+masticador de alfombras
+masticar trasero
+masturbacion
+masturbar
+masturbarse
+matosurrero
+me cago en su madre
+me llegas al pincho
+me pelas la pija
+me vale verga
+meapilas
+meason
+mecaniquito
+menaje
+menopausica
+menso
+mentirosa
+mentiroso
+mercachifle
+metedura de pata
+metelo
+metomentodo
+mica
+micha
+michita
+mico
+microondas
+mierda
+mierdamierdahijo de puta
+mierdoza
+mierdozo
+mio
+moclin
+moco
+moja’ el picure
+mojonero
+monda
+mongol
+mongolico
+mongolo
+mono gallo
+moquito
+moras
+mordaza de bola
+mordedura de gallo
+mordida
+moreno
+morlaco
+moromierda
+morronga
+mostro
+mota
+muerdealmohada
+muergana
+muergano
+mula
+nabo
+nalgas
+nariz de gallo
+nazi
+negro
+neja
+nejo
+nengue
+nera
+nero
+nica
+niche
+nina en la cima
+no jodas
+no sirves pa ni mierda
+nojo
+nojoda
+nona
+noneco
+nono
+nucleo duro
+nudoso
+nuez
+ocote
+ojete
+oleoducto de alaska
+olluo
+orgia
+orgias
+ortiva
+orto
+ostia
+pacharro
+paco
+pacucuso
+pacufo
+pacuso
+pacusobo
+paga peo
+paga prote
+pagafantas
+paja
+paja de pies
+pajaro
+pajaron
+pajizo
+pajua
+pajuo
+pajuso
+palo
+paloma
+panal caga’o
+pandorga
+panocha
+papaya
+papo
+parcha
+parchita
+pargo
+pargula
+parido por el sobaco
+pasmado
+pastelero
+pastrulo
+pata e’ rolo
+patear el tobo
+patear la pelota
+pato
+payaso
+pea
+pechos grandes
+pecuso
+pedazo de mierda
+pedo
+pedofilo
+pegoste de olla
+peinabombillas
+pelele
+pelota lamiendo
+pelotas
+pelotudo
+penco
+pencon
+pendeja
+pendejo
+pene
+peo
+pepa del culo
+pepita
+perilla
+perillaoriental
+perillas
+perra
+perras
+perro
+perro e’ quinta
+perro e’ rancho
+perroflauta
+persiguiendo
+pervertido
+pete
+petimetre
+petizo
+pezcao
+picador
+picazon
+picha
+pichicosa
+pichinga
+pichon de cabron
+pichurria
+pico
+pie de atleta
+pija
+pijotero
+pincharrata
+pinche
+pinga
+pingo
+pipian
+pirinola
+piripicho
+piroba
+pirobo
+pisa
+pisa huevos
+pisa ninas
+pistola con la mano
+pitillo
+plaga
+plasta
+playo
+plegocha
+pocha
+polla
+polla gigante
+pollas
+pollasuka
+pollerudo
+poluta
+poluto
+polvo del gallo
+polvo del kerosene
+ponche de burro
+pordiosero
+porqueria
+porton de iglesia
+poto
+pozo
+primo
+prostituta
+pucha
+puchica
+pullar
+pullon
+puneta
+puno
+puno follado
+punto g
+pupu
+purruja
+puta
+puta de la cam
+puta madre
+putas
+puto
+putona
+puya
+quejandose
+quemero
+querrequerre
+queso
+quesua
+quesuo
+racamofin
+racimo de mierda
+raja
+rajunarepa
+ramera
+rata
+ratica
+realengo
+recochesumadre
+reconchesumare
+reconchetumadre
+recontra cono’e madre
+recontraconisimo
+recontraputa
+redoblona
+relambe guevo
+relambechupaverga
+relambepipe
+remojar el cochayuyo
+repipi
+reputa
+reputisima
+restriccion de cuero
+retrasado
+ridi
+ridiculo
+rizado
+rodaja de pina
+rolitranco
+rompeculos
+rosalada
+rosquete
+rosquilla de gelatina
+rozar las pelotas
+rubia sobre rubia accion
+ruchar
+sabolo
+saco de bolas
+saco de pelota
+saideliu
+salsa de bolas
+sambumbia
+samo
+sanaco
+sangriento
+sapa
+sapo
+sapo hijueputa
+se corre
+sebuda
+sebudo
+semen
+senor gay
+senos
+serrana
+serrano
+serruchar
+sexo caliente
+sexo duro
+sexo en grupo
+sexo gay
+si como ronca duerma
+sieso
+simeloma
+sin cojones
+sobraa
+sobrao
+socabron
+somamao
+sonzo
+sopendejo
+sopla condon
+sopla tu carga
+soplar el bisteck
+soplon
+su madre
+sucio
+sucio sanchez
+tacazo
+tara
+tarado
+taraila
+tarao
+tardo gay
+tarupido
+tatengue
+tavy
+temiga
+temigoso
+temigue
+tenso
+terruco
+teta
+tetas
+tetona
+tierruo
+timbal
+timonel
+tio
+tirado un pedo
+tirador
+tirando pedos
+tirar
+tirilla
+tiuque
+tocapelotas
+toche
+tontarron
+tontas
+tonterias
+tonto
+topar
+tortillera
+toto
+totona
+trabajo manual
+traficante de gallos
+traficante de pollas
+traga sable
+tragaleche
+tragasable
+trampolindebuchevergaoriental
+tranca
+trancado
+trasero
+trasero-pirata
+trastanuta
+travesti
+trimardito
+tripero
+triplehijueputa
+trolo
+tu madre
+tu taa loco
+tufo
+tuki
+tunco
+tusa
+tutifruto
+una mierda
+uyuyuy
+vaina
+vale picha
+vapor de cleveland
+vasito de agua
+venado
+venatica
+venatico
+verano
+verdugo
+verga
+vergacion
+vergatario
+verraco
+verriondo
+vete a la chingada
+veterano
+vibra de bala
+vicho
+violacion en una cita
+violin
+volar papagallo
+vuerga
+webon
+webonauta
+weon
+wepota
+wircha
+wircho
+wiro
+wueon
+xonga
+xongo
+yoyo
+zamarro
+zamuro
+zarzamora
+zascandil
+zingar
+zoquete
+zorimba
+zorimbo
+zorra
+zorritone
+zorro
+zorrupia
+zunga
+zurdo
+zurumbatico

--- a/tools/moderation/build-dictionary.js
+++ b/tools/moderation/build-dictionary.js
@@ -1,0 +1,101 @@
+import { writeFile, mkdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ProfanityEngine } from '@coffeeandfun/google-profanity-words';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const COUNTRY_CODES = [
+  'ARG', 'BOL', 'CHL', 'COL', 'CRI', 'CUB', 'DOM', 'ECU',
+  'ESP', 'GTM', 'HND', 'MEX', 'NIC', 'PAN', 'PER', 'PRI',
+  'PRY', 'SLV', 'URY', 'VEN',
+];
+
+const OUTPUT_TARGETS = [
+  resolve(__dirname, '..', '..', 'posts-service', 'app', 'Support', 'Moderation'),
+  resolve(__dirname, '..', '..', 'chat-service', 'app', 'Support', 'Moderation'),
+];
+
+function normalizeWord(value) {
+  return String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/^['"`´-]+|['"`´-]+$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function sanitizeWords(lines) {
+  return lines
+    .map(normalizeWord)
+    .filter((word) => word.length >= 2)
+    .filter((word) => /[a-zñ]/i.test(word))
+    .filter((word) => !word.startsWith('#'));
+}
+
+async function fetchText(url) {
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'upt-moderation-builder',
+      'Accept': 'text/plain, application/json;q=0.9, */*;q=0.8',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`No se pudo descargar ${url}: ${response.status}`);
+  }
+
+  return await response.text();
+}
+
+async function buildDictionary() {
+  const googleEngine = new ProfanityEngine({ language: 'es', testMode: true });
+  const googleWords = await googleEngine.all();
+
+  const countrySources = await Promise.all(
+    COUNTRY_CODES.map(async (code) => {
+      const url = `https://raw.githubusercontent.com/jfreddypuentes/spanlp/master/spanlp/dataset/${code}.txt`;
+      const text = await fetchText(url);
+      return {
+        code,
+        words: sanitizeWords(text.split(/\r?\n/)),
+      };
+    })
+  );
+
+  const allWords = new Set([
+    ...sanitizeWords(googleWords),
+    ...countrySources.flatMap((source) => source.words),
+  ]);
+
+  const mergedWords = Array.from(allWords).sort((a, b) => a.localeCompare(b, 'es'));
+
+  const metadata = {
+    generated_at: new Date().toISOString(),
+    google_language: 'es',
+    sources: [
+      'npm:@coffeeandfun/google-profanity-words (es)',
+      ...countrySources.map((source) => `spanlp:${source.code}`),
+    ],
+    counts: {
+      google_words: sanitizeWords(googleWords).length,
+      country_words: countrySources.reduce((sum, source) => sum + source.words.length, 0),
+      merged_words: mergedWords.length,
+    },
+  };
+
+  for (const targetDir of OUTPUT_TARGETS) {
+    await mkdir(targetDir, { recursive: true });
+    await writeFile(join(targetDir, 'profanity-es-hispano.txt'), `${mergedWords.join('\n')}\n`, 'utf8');
+    await writeFile(join(targetDir, 'profanity-es-hispano.meta.json'), `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
+  }
+
+  console.log(`Diccionario generado con ${mergedWords.length} entradas.`);
+}
+
+buildDictionary().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tools/moderation/package-lock.json
+++ b/tools/moderation/package-lock.json
@@ -1,0 +1,22 @@
+{
+  "name": "upt-moderation-tools",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "upt-moderation-tools",
+      "dependencies": {
+        "@coffeeandfun/google-profanity-words": "^3.0.7"
+      }
+    },
+    "node_modules/@coffeeandfun/google-profanity-words": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@coffeeandfun/google-profanity-words/-/google-profanity-words-3.0.7.tgz",
+      "integrity": "sha512-xbtxvk+MJbzRJHL2LyS/3YKkBQsqhK/aMI4OZQCNt3hW2b8WZ8zDKF+K+2925w5/mQdMC7RKN21LGaR0phnDmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/tools/moderation/package.json
+++ b/tools/moderation/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "upt-moderation-tools",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build-dictionary": "node build-dictionary.js"
+  },
+  "dependencies": {
+    "@coffeeandfun/google-profanity-words": "^3.0.7"
+  }
+}


### PR DESCRIPTION
Cierra #20

- arma un diccionario propio combinando la lista base en español con listados hispanos
- aplica moderación automática previa al guardado en publicaciones, comentarios y mensajes
- devuelve mensajes claros cuando detecta lenguaje no permitido